### PR TITLE
fix: no implicit conversion of Array into String

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ title: [FreeCAD Developers Handbook]
 description: [A handbook about FreeCAD development]
 
 # Where things are
-source              : [your repo's top level directory]
+source              : .
 destination         : ./_site
 collections_dir     : .
 plugins_dir         : _plugins # takes an array of strings and loads plugins in that order


### PR DESCRIPTION
When trying to build this site locally it gives the following error due to a misspelled string in _config.yml:

```txt
bundle exec jekyll serve
Configuration file: /Users/dirkolbrich/Code/freecad/freecad-DevelopersHandbook/_config.yml
jekyll 3.9.3 | Error:  no implicit conversion of Array into String
/Users/dirkolbrich/.gem/ruby/3.1.3/gems/jekyll-3.9.3/lib/jekyll/site.rb:20:in `expand_path': no implicit conversion of Array into String (TypeError)
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/jekyll-3.9.3/lib/jekyll/site.rb:20:in `initialize'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/jekyll-3.9.3/lib/jekyll/commands/build.rb:30:in `new'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/jekyll-3.9.3/lib/jekyll/commands/build.rb:30:in `process'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/jekyll-3.9.3/lib/jekyll/commands/serve.rb:93:in `block in start'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/jekyll-3.9.3/lib/jekyll/commands/serve.rb:93:in `each'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/jekyll-3.9.3/lib/jekyll/commands/serve.rb:93:in `start'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/jekyll-3.9.3/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/jekyll-3.9.3/exe/jekyll:15:in `<top (required)>'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/bin/jekyll:25:in `load'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/bin/jekyll:25:in `<top (required)>'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/cli/exec.rb:58:in `load'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/cli/exec.rb:58:in `kernel_load'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/cli/exec.rb:23:in `run'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/cli.rb:484:in `exec'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/cli.rb:31:in `dispatch'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/cli.rb:25:in `start'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/exe/bundle:48:in `block in <top (required)>'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/gems/bundler-2.3.3/exe/bundle:36:in `<top (required)>'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/bin/bundle:25:in `load'
        from /Users/dirkolbrich/.gem/ruby/3.1.3/bin/bundle:25:in `<main>'
```