### PR TITLE
Specify existent version of webrick dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
-gem "webrick", ">= 2.2.8"
+gem "webrick", ">= 1.8"
 
 


### PR DESCRIPTION
The Gemfile specifies `webrick 2.2.8`, but the latest version on [rubygems.org/gems/webrick](https://rubygems.org/gems/webrick) is 1.8.1.