### PR TITLE
Add --recurse-submodules to git clone commands

### DIFF
--- a/gettingstarted/CLion.md
+++ b/gettingstarted/CLion.md
@@ -8,7 +8,7 @@ If you don't already have CLion installed, download it, license it, install it p
 
 ### Checking out FreeCAD
 
-**Command line:**   `git clone https://github.com/FreeCAD/FreeCAD` and then File -> Open or New Project on that directory.
+**Command line:**   `git clone --recurse-submodules https://github.com/FreeCAD/FreeCAD` and then File -> Open or New Project on that directory.
 
 **IDE:** From upper left, choose Project from Version Control.   Use https://github.com/FreeCAD/FreeCAD
 ![Pict8](./resources/CLionPythonDebug8.png)

--- a/gettingstarted/index.md
+++ b/gettingstarted/index.md
@@ -43,7 +43,7 @@ that you can run your build system in. For example, on MacOS from the top of a F
 ## Setting up for Development
 
 1. Fork [https://github.com/FreeCAD/FreeCAD](https://github.com/FreeCAD/FreeCAD) on GitHub
-2. Clone your fork: for example, on the command line you can use `git clone https://github.com/YourUsername/FreeCAD FreeCAD-src`
+2. Clone your fork: for example, on the command line you can use `git clone --recurse-submodules https://github.com/YourUsername/FreeCAD FreeCAD-src`
 3. Set up `pre-commit` (our automatic code-formatter and checker):
 
 


### PR DESCRIPTION
Adds `--recurse-submodules` to `git clone`commands. As suggested in https://github.com/FreeCAD/FreeCAD/issues/16253#issuecomment-2354210005