### PR TITLE
Use color defined on linked web page

### DIFF
--- a/designguide/logo.md
+++ b/designguide/logo.md
@@ -66,7 +66,7 @@ Regardless of the used symbol, the wordmark *FreeCAD* must always be used in eit
 
 - **Dark Red**, [#CB333B, RGBA(203,51,59,1), CMYK(0,75,72,18), PMS 1797 C](https://encycolorpedia.com/cb333b)
 
-- **Off Black**, [#212529, RGBA(33,37,41,1), CMYK(0,0,16,82), PMS BLACK C](https://encycolorpedia.com/212529)
+- **Off Black**, [#212529, RGBA(33,37,41,1), CMYK(20,10,0,84), PMS BLACK C](https://encycolorpedia.com/212529)
 
 
 ## Uses


### PR DESCRIPTION
As mentioned here (which was missed during the merge-meeting) https://github.com/FreeCAD/DevelopersHandbook/pull/108#discussion_r1856221202 :

> [..] according to the linked web page, CMYK for the referenced off-black is: `cyan: 20% (0.195), magenta: 10% (0.098), yellow: 0% (0.0), key: 84% (0.839)` => `CMYK(20,10,0,84)`