### PR TITLE
Fix the wording "counter example"

### DIFF
--- a/bestpractices/c++practices.md
+++ b/bestpractices/c++practices.md
@@ -268,7 +268,7 @@ auto xyz = <whatever>_cast<Xyz>(...);
 auto xyz = getAnything<Xyz>(...);
 ```
 
-Counter examples:
+Examples with unclear types:
 
 ```c++
 auto value = randomThing.weirdProperty->getValue(); // non-obvious type


### PR DESCRIPTION
Make a small fix in reaction to [this feedback](https://github.com/FreeCAD/DevelopersHandbook/pull/123/files#r2029402752) by @benj5378.