### PR TITLE
Fix hyperlink name in OpenCascade online documentation link

### DIFF
--- a/technical/index.md
+++ b/technical/index.md
@@ -73,6 +73,6 @@ Technical information of interest to Contributors.
 
 - [OpenCascade Tutorials](http://opencascade.wikidot.com/romansarticles)
 - [OpenCascade overview presentation](https://dev.opencascade.org/sites/default/files/pdf/Topology.pdf)
-- [OpenCasacde_online_documentation](https://dev.opencascade.org/doc/overview/html/index.html)
+- [OpenCasacde online documentation](https://dev.opencascade.org/doc/overview/html/index.html)
 
 - [Scripted Objects](https://wiki.freecad.org/Scripted_objects)


### PR DESCRIPTION
Replaces underscores with whitespace