### PR TITLE
[ Fix ] Page Config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@ gist:
   noscript: false
 remote_theme: pages-themes/slate
 
-title: [FreeCAD Developers Handbook]
-description: [A handbook about FreeCAD development]
+description : 'A handbook about FreeCAD development'
+title : 'FreeCAD Developers Handbook'
 
 # Where things are
 source              : .


### PR DESCRIPTION
Fixes the `title` & `description` of pages.

### Before

<img width="262" height="122" alt="image" src="https://github.com/user-attachments/assets/4d9b227b-d8e9-4fef-9c9f-a98ea76117b1" />

<img width="439" height="157" alt="image" src="https://github.com/user-attachments/assets/0c5a6cc2-3566-4345-8387-fd108d7cbb08" />


### After

<img width="255" height="110" alt="image" src="https://github.com/user-attachments/assets/c0ea8f49-d8e0-4b2f-b85c-9e190bcb34ef" />

<img width="455" height="130" alt="image" src="https://github.com/user-attachments/assets/632b4ce3-99bf-4a92-bee7-07e755114c95" />
