### PR TITLE
Update Developer Hub with links to Addon-Academy, SourceDoc, and lens-docs

### DIFF
--- a/gettingstarted/index.md
+++ b/gettingstarted/index.md
@@ -116,6 +116,10 @@ The Visual Studio Installer may be used to install Visual Studio Community 2022 
 The GitHub issues tracker contains a 'Good First Issue' tag. Filtering by this tag will show issues that are well suited for new contributors.
 Try to find an issue that seems like an obvious win. If your issue seems unclear or complex, and you've given it a good shot, consider asking for help on Discord or the Forum before investing too much time (see below).
 
+### Developing Addons and Workbenches
+
+If you are interested in creating addons or workbenches for FreeCAD, the [Addon Academy](https://github.com/FreeCAD/Addon-Academy) provides comprehensive guides covering the full addon lifecycle — from project creation and scaffolding with Cookiecutter, through development and testing, to publishing via the Addon Manager and long-term maintenance. It also covers important topics like licensing, dependency management, and code structuring.
+
 Please note: While existing contributors try their best to be helpful, open source projects attract many first-time contributors, many of whom may not stick around for long.
 As such, existing contributors have limited time to help all newcomers. Please don't be offended if your questions go unanswered. Your contributions are still appreciated.
 

--- a/index.md
+++ b/index.md
@@ -22,3 +22,29 @@ Gives guidelines to maintainers about code reviews and merge procedures.
 
 ### [Technical Guide](./technical)
 A guide for developers learning their way around the FreeCAD codebase.
+
+---
+
+## Related Developer Resources
+
+Over time, developer-related content has grown and spread across several dedicated repositories. The following resources complement this handbook and should be consulted for specialized topics:
+
+### [Addon Academy](https://github.com/FreeCAD/Addon-Academy)
+Documentation, examples, and guides on how to develop FreeCAD addons. Covers the full addon lifecycle including creation, development, polishing, publishing, and maintenance. If you are interested in building addons or workbenches for FreeCAD, this is the primary resource.
+
+**Key topics covered:**
+- [Creating an addon](https://freecad.github.io/Addon-Academy/Guides/Creating/) — project scaffolding with Cookiecutter
+- [Developing an addon](https://freecad.github.io/Addon-Academy/Guides/Developing/) — coding, testing, and debugging
+- [Publishing an addon](https://freecad.github.io/Addon-Academy/Guides/Publishing/) — packaging and distribution via the Addon Manager
+- [Maintaining an addon](https://freecad.github.io/Addon-Academy/Guides/Maintaining/) — versioning, updates, and long-term upkeep
+- [Topic deep-dives](https://freecad.github.io/Addon-Academy/Topics/) — licensing, structuring, dependencies, types, and glossary
+
+### [Source Documentation (SourceDoc)](https://github.com/FreeCAD/SourceDoc)
+Doxygen-generated API documentation for the FreeCAD C++ source code. This provides class hierarchies, method signatures, and detailed reference documentation for core modules.
+
+> **Note:** The SourceDoc is currently based on FreeCAD version 0.20 and may not reflect the latest API changes in the development branch. For the most up-to-date API information, consider generating the documentation locally from the source tree, or consult the [Python stubs package](./technical/PythonStubsPackage) for Python-level API reference.
+
+### [Ondsel Lens Documentation](https://github.com/FreeCAD/lens-docs)
+Documentation for [Ondsel Lens](https://lens.ondsel.com/), a free/libre product data management (PDM) system designed for FreeCAD and FreeCAD-based software. Covers the web interface for managing CAD data, version control, and collaboration features.
+
+This is relevant for developers building workflows that integrate with cloud-based PDM or collaborative design features.

--- a/technical/Websites.md
+++ b/technical/Websites.md
@@ -104,8 +104,39 @@ assets of the FreeCAD project.
 
 ### [Crowdin][Page-Crowdin]
 
-Translation platform used for the FreeCAD  
+Translation platform used for the FreeCAD
 app and homepage as well as some addons.
+
+<br/>
+
+## Developer Resources
+
+The following resources are specifically
+aimed at FreeCAD developers.
+
+### [Addon Academy][Repo-AddonAcademy]
+
+Guides and examples for developing,
+publishing, and maintaining FreeCAD addons.
+
+The site is built using [Jekyll]
+and written in simple Markdown.
+
+<br/>
+
+### [Source Documentation][Repo-SourceDoc]
+
+Doxygen-generated C++ API reference
+for the FreeCAD source code.
+
+<br/>
+
+### [Ondsel Lens Documentation][Repo-LensDocs]
+
+Documentation for Ondsel Lens, a free/libre
+product data management system for FreeCAD.
+
+The site is built using [Hugo].
 
 <br/>
 
@@ -118,6 +149,9 @@ app and homepage as well as some addons.
 [Repo-Homepage]: https://github.com/FreeCAD/FreeCAD-Homepage
 [Repo-Wiki]: https://github.com/Reqrefusion/FreeCAD-Documentation-Project
 [Repo-FPA]: https://github.com/FreeCAD/FPA
+[Repo-AddonAcademy]: https://github.com/FreeCAD/Addon-Academy
+[Repo-SourceDoc]: https://github.com/FreeCAD/SourceDoc
+[Repo-LensDocs]: https://github.com/FreeCAD/lens-docs
 
 [Page-Handbook]: https://freecad.github.io/DevelopersHandbook
 [Page-Homepage]: https://freecad.org
@@ -133,6 +167,7 @@ app and homepage as well as some addons.
 [WordPress]: https://wordpress.org
 [MediaWiki]: https://mediawiki.org
 [Jekyll]: https://jekyllrb.com
+[Hugo]: https://gohugo.io
 [jQuery]: https://jquery.com
 [phpBB]: https://www.phpbb.com
 [PHP]: https://www.php.net

--- a/technical/index.md
+++ b/technical/index.md
@@ -65,6 +65,12 @@ Technical information of interest to Contributors.
 
 ## See Also
 
+- [Addon Academy](https://github.com/FreeCAD/Addon-Academy) — Comprehensive guides for developing, publishing, and maintaining FreeCAD addons
+
+- [Source Documentation (SourceDoc)](https://github.com/FreeCAD/SourceDoc) — Doxygen-generated C++ API reference (based on FreeCAD 0.20)
+
+- [Ondsel Lens Documentation](https://github.com/FreeCAD/lens-docs) — Documentation for the Ondsel Lens PDM system
+
 - [Wiki Developer Hub](https://wiki.freecad.org/Developer_hub)
 
 - [Compiling](https://wiki.freecad.org/Developer_hub#Compiling_FreeCAD)


### PR DESCRIPTION
## Summary

Developer-related content has spread across several repositories over time. This PR updates the Developer Hub to serve as a central navigation point by integrating references to three key developer resources:

### Changes

1. **index.md** - Added a new **"Related Developer Resources"** section with:
   - **Addon Academy**: Comprehensive guides for addon development, publishing, and maintenance (with links to key topic pages)
   - **SourceDoc**: Doxygen-generated C++ API reference (with a note about its 0.20 version status)
   - **Ondsel Lens Documentation**: Documentation for the Lens PDM system

2. **	echnical/index.md** - Added Addon Academy, SourceDoc, and Lens docs to the "See Also" section

3. **	echnical/Websites.md** - Added a new **"Developer Resources"** subsection with repository links for all three resources

4. **gettingstarted/index.md** - Added an Addon Academy reference under "Finding Tasks to Work On" for developers interested in building addons/workbenches

### Related Issue

Addresses Reqrefusion/FreeCAD-Documentation-Project#329 - "Updating the Developer Hub"