### PR TITLE
Document related FreeCAD developer resources

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,6 +2,8 @@
 
 Welcome to the FreeCAD Developer's Guide! This is a work-in-progress, so please feel free to submit Issues and Pull Requests when you find areas that need work.
 
+The FreeCAD developer documentation is spread across several projects. For module-specific or legacy material, see the [Addon Academy](https://github.com/FreeCAD/Addon-Academy), [SourceDoc](https://github.com/FreeCAD/SourceDoc), [lens-docs](https://github.com/FreeCAD/lens-docs), and the [legacy wiki Developer Hub](https://wiki.freecad.org/Developer_hub).
+
 ### [Roadmap](./roadmap)
 Describes the broad objectives for FreeCAD Development
 

--- a/technical/index.md
+++ b/technical/index.md
@@ -65,7 +65,11 @@ Technical information of interest to Contributors.
 
 ## See Also
 
-- [Wiki Developer Hub](https://wiki.freecad.org/Developer_hub)
+- [FreeCAD Developers Handbook](https://freecad.github.io/DevelopersHandbook/)
+- [Addon Academy](https://github.com/FreeCAD/Addon-Academy)
+- [SourceDoc](https://github.com/FreeCAD/SourceDoc)
+- [lens-docs](https://github.com/FreeCAD/lens-docs)
+- [Legacy wiki Developer Hub](https://wiki.freecad.org/Developer_hub)
 
 - [Compiling](https://wiki.freecad.org/Developer_hub#Compiling_FreeCAD)
 


### PR DESCRIPTION
This PR updates the handbook homepage and technical guide to point readers toward the current FreeCAD developer documentation ecosystem: Addon Academy, SourceDoc, lens-docs, and the legacy wiki Developer Hub.\n\nIt helps address the outdated developer hub situation referenced in Reqrefusion/FreeCAD-Documentation-Project#329 by making the current resources easier to find from the handbook.